### PR TITLE
simple static code analysis with eslint

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,16 @@
+
+{
+    "parserOptions": {
+        "ecmaVersion": 6,
+        "sourceType": "module",
+        "ecmaFeatures": {
+            "jsx": true
+        }
+    },
+
+    "rules": {
+        "no-eval": 2,
+        "no-alert": 2,
+        "no-console": 2
+    }
+}

--- a/README.md
+++ b/README.md
@@ -17,15 +17,15 @@ It will search through the extracted or mounted firmware file system for things 
 * NOTE: Some of the data written to the file may be quite verbose. It that case, the data can be reviewed and then deleted if desired from the file.
 
 ## Usage
-* Firstly instal eslint: ´npm i -g eslint´
-* './firmwalker {path to root file system}'
-* Example: './firmwalker linksys/fmk/rootfs'
-* A file "firmwalker.txt" will be created in the same directory as the script file unless you specify a different filename as the second argument
+* Firstly instal eslint: `npm i -g eslint`
+* `./firmwalker {path to root file system}`
+* Example: `./firmwalker linksys/fmk/rootfs`
+* A file `firmwalker.txt` will be created in the same directory as the script file unless you specify a different filename as the second argument
 * Do not put the firmwalker.sh file inside the directory to be searched, this will cause the script to search itself and the file it is creating
-* chmod 0700 firmwalker.sh
+* `chmod 0700 firmwalker.sh`
 
 ## How to extend
-* Have a look under data where the checks live - feel free to extend as you see fit
+* Have a look under data where the checks live or add eslint rules- feel free to extend as you see fit
 
 ### Script created by Craig Smith and expanded by Athanasios Kostopoulos
 * https://craigsmith.net

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ It will search through the extracted or mounted firmware file system for things 
 * NOTE: Some of the data written to the file may be quite verbose. It that case, the data can be reviewed and then deleted if desired from the file.
 
 ## Usage
+* Firstly instal eslint: ´npm i -g eslint´
 * './firmwalker {path to root file system}'
 * Example: './firmwalker linksys/fmk/rootfs'
 * A file "firmwalker.txt" will be created in the same directory as the script file unless you specify a different filename as the second argument

--- a/firmwalker.sh
+++ b/firmwalker.sh
@@ -142,13 +142,18 @@ done
 msg ""
 msg "***Search for ip addresses***"
 msg "##################################### ip addresses"
-grep -RIEo '[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}' $FIRMDIR | awk -F ":" '{print $2$3}' | uniq | tee -a $FILE
+grep -RIEho '[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}' $FIRMDIR  | uniq | tee -a $FILE
 
 
 msg ""
 msg "***Search for urls***"
 msg "##################################### urls"
-grep -RIEo '(http|https)://[^/"]+' $FIRMDIR | awk -F ":" '{print $2$3}' | uniq | tee -a $FILE
+grep -RIEoh '(http|https)://[^/"]+' $FIRMDIR  | uniq | tee -a $FILE
+
+msg ""
+msg "***Search for emails***"
+msg "##################################### emails"
+grep -EIorh '([[:alnum:]_.-]+@[[:alnum:]_.-]+?\.[[:alpha:].]{2,6})' "$@" $FIRMDIR | sort | uniq | tee -a $FILE
 
 #Perform static code analysis 
 eslint -c .eslintrc.json $FIRMDIR | tee -a $FILE

--- a/firmwalker.sh
+++ b/firmwalker.sh
@@ -138,3 +138,6 @@ do
     find $FIRMDIR -name "$binary" | cut -c${#FIRMDIR}- | tee -a $FILE
     msg ""
 done
+
+#Perform static code analysis 
+eslint -c .eslintrc.json $FIRMDIR | tee -a $FILE

--- a/firmwalker.sh
+++ b/firmwalker.sh
@@ -139,5 +139,16 @@ do
     msg ""
 done
 
+msg ""
+msg "***Search for ip addresses***"
+msg "##################################### ip addresses"
+grep -RIEo '[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}' $FIRMDIR | awk -F ":" '{print $2$3}' | uniq | tee -a $FILE
+
+
+msg ""
+msg "***Search for urls***"
+msg "##################################### urls"
+grep -RIEo '(http|https)://[^/"]+' $FIRMDIR | awk -F ":" '{print $2$3}' | uniq | tee -a $FILE
+
 #Perform static code analysis 
 eslint -c .eslintrc.json $FIRMDIR | tee -a $FILE


### PR DESCRIPTION
If you don't mind adding a npm module it's simple as that. There is only 3 rules used atm but it's just a matter of adding rules from http://eslint.org/docs/rules/ also we could create custom rules which will be better of course (for example detecting console.log/alert when it's outputting a variable and not some fixed string is better)
Example output of ./firmwalker : https://gist.github.com/misterch0c/01b250f4493d3ee3c1e8 
Maybe it would also be better to create 2 files? One for the grep results and one for eslint.
