### PR TITLE
Better IP regex

### DIFF
--- a/firmwalker.sh
+++ b/firmwalker.sh
@@ -166,7 +166,7 @@ done
 msg ""
 msg "***Search for ip addresses***"
 msg "##################################### ip addresses"
-grep -sRIEho '[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}' --exclude-dir='dev' $FIRMDIR | sort | uniq | tee -a $FILE
+grep -sRIEho '\b(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\b' --exclude-dir='dev' $FIRMDIR | sort | uniq | tee -a $FILE
 
 msg ""
 msg "***Search for urls***"


### PR DESCRIPTION
I've noticed that firmwalker has been matching some things which look like IPs but aren't. I've replaced the regex with the one from here: http://www.regular-expressions.info/ip.html, and it works better.